### PR TITLE
Doctype must be declared first.の修正

### DIFF
--- a/app/templates/weather_info.html
+++ b/app/templates/weather_info.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 {% extends "base.html" %}
 
 {% block content %}


### PR DESCRIPTION
Doctype must be declared first.の修正
HTMLファイルの最初に<!DOCTYPE html>をついか